### PR TITLE
Fixed `Unknown custom element` warnings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,16 @@ import App from './App.vue'
 
 import 'aframe';
 
+Vue.config.ignoredElements = [
+  'a-scene',
+  'a-assets',
+  'a-sky',
+  'a-camera',
+  'a-cursor',
+  'a-animation',
+  'a-entity'
+]
+
 new Vue({
   el: '#app',
   render: h => h(App)


### PR DESCRIPTION
Added ignoredElements to get around `[Vue warn]: Unknown custom element: …` 
More info → https://github.com/frederic-schwarz/aframe-vuejs-3dio/issues/1